### PR TITLE
URL fix: Update repository URL in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To build the project, follow these steps:
   
 
 ```shell
-git clone <rhttps://github.com/realayna/tictac-toe-ai>
+git clone https://github.com/realayna/tictac-toe-ai.git
 ```
   
   


### PR DESCRIPTION
Changed the repository URL from <rhttps://github.com/realayna/tictac-toe-ai> to https://github.com/realayna/tictac-toe-ai.git for correct cloning instructions.